### PR TITLE
fix(application.dto): fix isQuick transform error when field is 'false'

### DIFF
--- a/packages/backend/src/dtos/application.dto.ts
+++ b/packages/backend/src/dtos/application.dto.ts
@@ -1,4 +1,4 @@
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import { IsBoolean, IsDateString, IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
 
 import { Grade, Group, InterviewType, Rank, Step } from '@constants/enums';
@@ -41,7 +41,7 @@ export class SetApplicationBody {
 
 export class CreateApplicationBody extends SetApplicationBody {
     @IsBoolean()
-    @Type(() => Boolean)
+    @Transform(({ value }) => (typeof value === 'string' ? value === 'true' : Boolean(value)))
     isQuick!: boolean;
 
     @IsUUID(4)


### PR DESCRIPTION
FormData's value is always string and needs transformation
`@Type(() => Boolean)`无法正确转换`'false'` [](https://github.com/typestack/class-transformer/issues/711)
暂时使用`@Transfrom`替代